### PR TITLE
Update to use Nightmare 2.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,23 @@ A hack to get Workflowy export through headless browser automation.
 
 ## Requirements
 
-- NodeJS & NPM
-- PhantomJS
+- Node & NPM
 
 ## Setup
 
-Install Nightmare:
+Install Nightmare, Electron and dependacies:
 
 ```bash
 make build
 ```
 
-Create a `local.sh` with Workflowy credentials.
+Create a `local.sh` file in the same directory with your Workflowy credentials.
 
 ```bash
 #!/bin/bash
 
-export USERNAME="your_username"
-export PASSWORD="your_password"
+export USERNAME="my_username"
+export PASSWORD="my_password"
 
 node .
 ```

--- a/backup.js
+++ b/backup.js
@@ -9,23 +9,25 @@ nightmare
   .type('#id_username', process.env.USERNAME)
   .type('#id_password', process.env.PASSWORD)
   .click('[type=submit]')
-  .wait()
+  .wait(5000)
 
   // open export panel
   .click('#exportAllButton')
-  .wait('.id_text')
+  .wait('#id_text')
   .click('#id_text')
-  .wait(500)
 
   // scrape content
   .evaluate(function () {
     return document.querySelector('.previewWindow pre').innerText;
-  }, function (exportText) {
+  })
+  .end()
+  .then(function (exportText) {
     var filename = 'workflowy_export.txt';
-    console.log('Saving export to ' + filename);
+    console.log('Backup saved to ' + filename);
     fs.writeFile(filename, exportText);
   })
 
-  .run(function(err, nightmare){
-    console.log('Done.');
+  // show any errors if there are any
+  .catch(function(err){
+    console.log(err);
   });

--- a/package.json
+++ b/package.json
@@ -9,6 +9,6 @@
   "author": "Mat Harden <matharden@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "nightmare": "^1.8.2"
+    "nightmare": "^2.9.1"
   }
 }


### PR DESCRIPTION
Nightmare now uses Electron rather than PhantomJS which means a promise should be used.

Fixes #1 